### PR TITLE
move 0 to the right of 9

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,9 +98,9 @@
       </div>
       <div>
         <span>Piano</span>
-        <span class="key">0</span>
         <span class="key">1</span> ...
         <span class="key">9</span>
+        <span class="key">0</span>
       </div>
       <div>
         <span>Marimba</span>


### PR DESCRIPTION
0 is to the right of 9 on a US keyboard, and I'm not aware of any other keyboard layouts where that is not the case.  Closes #69