### PR TITLE
Stop keypress event bubbling

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -243,6 +243,7 @@ $(document).on("mousedown mouseup", function(e) {
   }
 });
 $(document).on("keydown keyup", function(e) {
+  e.preventDefault();
   var instrument = InstrumentPerKeyEnum[e.key.toUpperCase()];
   var key = KeyEnum[e.key.toUpperCase()];
   if (instrument != undefined && key != undefined) {


### PR DESCRIPTION
This prevents keypress events from bubbling up to the window/document, where they might trigger things like find-as-you-type or other hotkeys. Those browser actions might steal focus and keep the site from working.