### PR TITLE
Add link on README.md image to https://bongo.cat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Bongo Cat
 <p align="center">
-  <img src="https://bongo.cat/meta/thumbnail.png">
+  <a href="https://bongo.cat">
+    <img src="https://bongo.cat/meta/thumbnail.png">
+  </a>  
 </p>
 Hit the bongos like Bongo Cat! https://bongo.cat
 


### PR DESCRIPTION
I added a feature (just a link) so when you click on the image it redirects you to the [bongo.cat](https://bongo.cat/) site. 

This will help the users reading the `README.md` doc that click on the image to access the site easier 😄 
