### PR TITLE
Match Piano/Marimba hands to direction on keyboard

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -185,7 +185,7 @@ $.wait = function(callback, ms) {
 $.play = function(instrument, key, state) {
   var instrumentName = Object.keys(InstrumentEnum).find(k => InstrumentEnum[k] === instrument).toLowerCase();
   var commonKey = KeyEnum[key];
-  var id = "#" + (instrument == InstrumentEnum.MEOW ? "mouth" : "paw-" + ((instrument == InstrumentEnum.BONGO ? commonKey : commonKey <= 5 && commonKey != 0 ? 0 : 1) == 0 ? "left" : "right"));
+  var id = "#" + (instrument == InstrumentEnum.MEOW ? "mouth" : "paw-" + ((instrument == InstrumentEnum.BONGO ? commonKey : commonKey <= 5 && commonKey != 0 ? 1 : 0) == 0 ? "left" : "right"));
   if (state == true) {
     if (jQuery.inArray(commonKey, pressed) !== -1) {
       return;


### PR DESCRIPTION
Left click ( and A ) plays the left bongo, Right click ( and D )
plays the right bongo. It is therefore logical that the keyboard
keys 1-5, and Q-T play the left Piano and Marimba keys respectively,
and that the keyboard keys 6-0 and Y-P play the right Piano and Marimba
keys respectively.

This patch fixes this visual bug and soothes my OCD.