### PR TITLE
Key to match keyboard/marimba tone

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,18 +145,18 @@
       <div class="tap" id="tap-space"><span i18n="MEOW">MEOW</span></div>
       <div id="tap-keys">
         <div>
-          <div class="tap" id="tap-1"><span>1</span></div>
-          <div class="tap" id="tap-2"><span>2</span></div>
-          <div class="tap" id="tap-3"><span>3</span></div>
-          <div class="tap" id="tap-4"><span>4</span></div>
-          <div class="tap" id="tap-5"><span>5</span></div>
+          <div class="tap" id="tap-1"><span>C</span></div>
+          <div class="tap" id="tap-2"><span>C#</span></div>
+          <div class="tap" id="tap-3"><span>D</span></div>
+          <div class="tap" id="tap-4"><span>D#</span></div>
+          <div class="tap" id="tap-5"><span>E</span></div>
         </div>
         <div>
-          <div class="tap" id="tap-6"><span>6</span></div>
-          <div class="tap" id="tap-7"><span>7</span></div>
-          <div class="tap" id="tap-8"><span>8</span></div>
-          <div class="tap" id="tap-9"><span>9</span></div>
-          <div class="tap" id="tap-0"><span>0</span></div>
+          <div class="tap" id="tap-6"><span>F</span></div>
+          <div class="tap" id="tap-7"><span>F#</span></div>
+          <div class="tap" id="tap-8"><span>G</span></div>
+          <div class="tap" id="tap-9"><span>G#</span></div>
+          <div class="tap" id="tap-0"><span>A</span></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
# What this commit introduces

- I can confirm that both the marimba and keyboard tones' range is C to A (C-C#-D-D#-E-F-F#-G-G#-A)
- It's more intuitive for users to label the keys (at least on mobile display) to match with the actual tone of the sound.